### PR TITLE
Adding the optional realm parameter to requests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,8 @@ Sending requests works very similar to the latest version of node's built-in htt
 		path: '/1/statuses/update.json',
 		oauth_signature: signer,
 		method: 'POST',
-		body: body
+		body: body,
+        realm: 'my_realm'
 	}
 	
 	request = oauth.request(request, function(response) { ... });

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -116,7 +116,7 @@ exports.request = function(options, callback) {
 		'content-type': 'application/x-www-form-urlencoded',
 		'host': options.host,
 		'accept': '*/*',
-		'www-authenticate': 'OAuth realm=' + (options.https ? 'https' : 'http') + '://' + options.host
+		'www-authenticate': 'OAuth realm=' + (options.realm ? options.realm : ((options.https ? 'https' : 'http') + '://' + options.host))
 	};
 
 	if(!options.headers) {
@@ -128,7 +128,7 @@ exports.request = function(options, callback) {
 
 	var uri = exports.fillURL(options.path, options.host, options.port, options.https);
 	options.headers = signRequest(options.method, uri, options.headers, 
-		options.body, options.oauth_signature);
+		options.body, options.oauth_signature, options.realm);
 
 	var req;
 	if (options.https) {
@@ -144,11 +144,12 @@ exports.request = function(options, callback) {
 		
 		return http.ClientRequest.prototype.write.call(this, chunk, 'utf-8');
 	};
-
+    
+    req.end();
 	return req;
 };
 
-function signRequest(method, path, headers, body, signature) {
+function signRequest(method, path, headers, body, signature, realm) {
 	var auth = {
 		'oauth_nonce': nonce(),
 		'oauth_timestamp': timestamp(),
@@ -194,6 +195,7 @@ function signRequest(method, path, headers, body, signature) {
 	
 	var esc = querystring.escape;
 	querystring.escape = _encodeURI;
+    auth.realm = realm;
 	auth = querystring.stringify(exports.normalize(auth), '\",', '=\"');
 	querystring.escape = esc;
 

--- a/test/test_realm_signature.js
+++ b/test/test_realm_signature.js
@@ -1,0 +1,33 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    oauth = require('../lib/oauth'),
+	uuid = require('node-uuid');
+
+vows.describe('RealmSignatures') .addBatch({
+  'In a valid request token flow': {
+    topic: function() {
+      var hmac = oauth.createHmac(consumer,token);
+      var consumer = oauth.createConsumer( 'sign_key', 'sign_secret' );
+      var token = null;
+      var signed = oauth.createHmac( consumer, token );
+      var method = 'post',
+          url = 'http://api.google.com/oauth',
+          realm = 'testable_realm',
+          params = {
+            oauth_signature_method:'HMAC-SHA1',
+            oauth_version:'1.0'
+          };
+      return oauth.signRequest(method, url, {}, {}, signed, realm);
+    },
+    'Auth header should be set to ': function(topic) {
+
+    var oauth_pattern = /OAuth oauth_consumer_key\=\"sign_key\"\,oauth_nonce\=\"[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}\"\,oauth_signature_method\=\"HMAC-SHA1\"\,oauth_timestamp\=\"[0-9]{10}\"\,oauth_version\=\"1\.0\"\,realm\=\"testable_realm\"\,oauth_signature\=/g;
+
+    var matched = oauth_pattern.exec(topic.authorization);
+    if ( assert.isArray( matched ) ) {
+        return assert.isNotEmpty( matched );
+    }
+    return false;
+    }
+  }
+}).export(module);


### PR DESCRIPTION
The realm parameter can now be added through options to the request, which will become part of the encoded Authorization header.  For more information, please see:
http://oauth.net/core/1.0a/#rfc.section.5.4.1

There is also a new test file for  the functionality and changes to the Readme.   I also added a call to req.end() to send this file.  Not sure if this is necessary.
