### PR TITLE
Fix missing exports in front of merge(...)

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -280,7 +280,7 @@ Token.prototype.encode = function(str) {
 	var ret = { oauth_token: this.oauth_token };
 
 	if(this.oauth_verifier) {
-		merge(ret, { oauth_verifier: this.oauth_verifier });
+		exports.merge(ret, { oauth_verifier: this.oauth_verifier });
 	}
 
 	return ret;


### PR DESCRIPTION
Ran into this when trying to consume an API that required the oauth_verifier parameter.
