### PR TITLE
Fix default_headers.host to include the port number

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -114,7 +114,7 @@ exports.request = function(options, callback) {
 
 	var default_headers = {
 		'content-type': 'application/x-www-form-urlencoded',
-		'host': options.host,
+		'host': options.host + (options.port ? ":"+options.port : ""),
 		'accept': '*/*',
 		'www-authenticate': 'OAuth realm=' + (options.realm ? options.realm : ((options.https ? 'https' : 'http') + '://' + options.host))
 	};


### PR DESCRIPTION
This change fixes the assembling of the signature-base-string on server-side, when the server is running in a customized port number.
