### PR TITLE
fix Signature in plain text

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -306,7 +306,7 @@ Signature.prototype.key = function() {
 };
 
 Signature.prototype.sign = function() {
-	return key;
+	return this.key();
 };
 
 Signature.prototype.baseString = function(method, url, params) {


### PR DESCRIPTION
This PR fixes the PLAINTEXT Signature mode:
createSignature(consumer, token)  previously threw [ReferenceError: key is not defined]  error.

Tests are passing. 
··············· ···· ····· ·· · ············· ········ ···· ······
  ✓ OK » 58 honored (0.059s)
